### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/hotsdraft_overlay/detection.py
+++ b/hotsdraft_overlay/detection.py
@@ -5,7 +5,7 @@ from typing import Optional, List, Any, Tuple
 import cv2
 import numpy as np
 import pytesseract
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 from hotsdraft_overlay import utils
 from hotsdraft_overlay.data import DataProvider
@@ -46,7 +46,7 @@ class Detector(object):
         best_map_name = None
         if game_map:
             for map_name in self.__data_provider.get_map_names():
-                score = fuzz.partial_ratio(map_name.lower(), game_map.lower())
+                score = fuzz.partial_ratio(map_name, game_map)
                 logging.debug("Got %d score for %s", score, map_name)
                 if score > best_score:
                     best_score = score

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2019.11.28
 chardet==3.0.4
 Desktopmagic==14.3.11
-fuzzywuzzy==0.18.0
+rapidfuzz==0.2.0
 idna==2.9
 keyboard==0.13.4
 numpy==1.18.1
@@ -11,7 +11,6 @@ Pillow==7.0.0
 PyQt5==5.14.1
 PyQt5-sip==12.7.1
 pytesseract==0.3.3
-python-Levenshtein==0.12.0
 # Providers win32gui which we can't get otherwise
 pywin32==227
 requests==2.23.0


### PR DESCRIPTION
FuzzyWuzzy and Python-Levenshtein are both GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fullz implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.

I never compiled RapidFuzz on Windows yet, so please let me know when there are any issues so I can resolve them ;)